### PR TITLE
add querystring to location pathname

### DIFF
--- a/src/components/privateroute/privateRoute.js
+++ b/src/components/privateroute/privateRoute.js
@@ -7,7 +7,9 @@ function PrivateRoute({ children }) {
 	const auth = useAuth();
 	const location = useLocation();
 	if (!auth.user.isLoggedIn) {
-		return <Navigate to={'/signup'} replace state={{ from: location }} />
+		return <Navigate to={'/signup'} replace state={
+			{ from: { pathname: location.pathname + location.search } }
+		} />;
 	}
 	return children;
 }

--- a/src/services/authentication.js
+++ b/src/services/authentication.js
@@ -184,7 +184,7 @@ export function AuthProvider({ children }) {
 		const options = {
 			method: 'GET'
 		};
-		let origin = location.pathname;
+		let origin = location.pathname + location.search;
 		if (excludeRedirects.includes(location.pathname)) {
 			origin = '/';
 		}


### PR DESCRIPTION
Make it so that querystring `?var=value` in some url like `url.com/some/route?var=value` will not be thrown away when redirecting user to and from signup/login. 