### PR TITLE
fix tt logo style

### DIFF
--- a/src/components/ttlogo/ttlogo.css
+++ b/src/components/ttlogo/ttlogo.css
@@ -7,7 +7,7 @@
     background: #252525;
     position: absolute;
     width: 250px;
-    height: 141px;
+    height: 165px;
 
     margin-left: 60px;
 

--- a/src/components/ttlogo/ttlogo.js
+++ b/src/components/ttlogo/ttlogo.js
@@ -10,7 +10,7 @@ function TTLogo({ className, developers }) {
 
 	return (
 		<div className={`ttlogo-main-container ${className}`}>
-			<a href="https://www.ai-camp.org/" className="tt-logo">
+			<a target="_blank" rel="noreferrer" href="https://www.ai-camp.org/team-tomorrow" className="tt-logo">
 				<img src={TTLogoSVG} alt="logo"/>
 			</a>
 
@@ -25,6 +25,7 @@ function TTLogo({ className, developers }) {
 					</p>
 					<p><span>Product Manager: </span> Sricharan Guddanti</p>
 					<p><span>Product Designer: </span> Bernice Lau</p>
+					<p><span>Engineering Managers: </span> Jackson Choyce, Alexander Zhou</p>
 					<p><span>Software Developers: </span> {developerString} </p>
 				</div>
 			</div>

--- a/src/pages/dashboard/dashboard.js
+++ b/src/pages/dashboard/dashboard.js
@@ -60,8 +60,7 @@ function Dashboard() {
 					<Outlet />
 				</div>
 			</div>
-			<TTLogo className='absolute bottom-1 left-1 p-6'/>
-
+			<TTLogo className='absolute bottom-1 left-1 p-6 text-white'/>
 		</div>
 	);
 }


### PR DESCRIPTION
- change text to white on dashboard
- add engineering manager section, hardcoded it, but could make it a prop like software developers if needed
- clicking on tt logo will open tab to TT website in new tab
![Screen Shot 2022-07-21 at 3 39 59 PM (2)](https://user-images.githubusercontent.com/59636409/180326976-744bbd76-3792-46d2-b03c-1bb9cba3597a.png)
