### PR TITLE
simplify initial loading screen to remove current errors

### DIFF
--- a/src/services/authentication.js
+++ b/src/services/authentication.js
@@ -314,10 +314,7 @@ export function AuthProvider({ children }) {
 
 	if (!checkLogin) {
 		return (
-			<AuthContext.Provider value={value}>
-				<Navbar />
-				<Loading />
-			</AuthContext.Provider>
+			<Loading />
 		);
 	}
 	return (

--- a/src/services/authentication.js
+++ b/src/services/authentication.js
@@ -3,7 +3,6 @@ import { useNavigate, useLocation, matchPath } from "react-router-dom";
 import sendReq from "./sendReq";
 import baseUrl from "../apiUrls";
 
-import Navbar from "../components/navbar/navbar";
 import Loading from "../pages/loading/loading";
 
 /**


### PR DESCRIPTION
When first opening the page, the navbar is rendered too, which causes issues since it depends on context. There are workarounds, but to prevent the need to make future workarounds I just decided to simplify the initial loading page to just the loading icon. 